### PR TITLE
fix: reenable building of arm-v7a

### DIFF
--- a/.github/workflows/android-build-scripts-did.yml
+++ b/.github/workflows/android-build-scripts-did.yml
@@ -58,7 +58,7 @@ jobs:
           echo "ANDROID_NDK_ROOT=$PWD/.ndk/$(ls .ndk)" >> $GITHUB_ENV
       - name: run the build script
         run: |
-          ./android.sh -d --enable-android-media-codec --enable-android-zlib --disable-arm-v7a --disable-arm-v7a-neon \
+          ./android.sh -d --enable-android-media-codec --enable-android-zlib --disable-arm-v7a-neon \
           --disable-x86 --disable-x86-64 --enable-gpl --enable-x264 --enable-libass --enable-libiconv
       - name: print build logs
         if: ${{ always() }}


### PR DESCRIPTION
## Description
The arm-v7a ABI was incorrectly disabled, causing runtime app crashes on devices running it.

## Type of Change
- Bug fix
