### PR TITLE
fix for code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android-build-scripts-did.yml
+++ b/.github/workflows/android-build-scripts-did.yml
@@ -1,4 +1,6 @@
 name: android build scripts
+permissions:
+  contents: write
 
 on:
   pull_request:

--- a/.github/workflows/ios-build-scripts-did.yml
+++ b/.github/workflows/ios-build-scripts-did.yml
@@ -12,6 +12,8 @@ on:
         required: true
         default: '16.1'
 
+permissions:
+  contents: write
 jobs:
   build-main-on-macos-sonoma:
     name: ios main on sonoma

--- a/.github/workflows/linux-build-scripts.yml
+++ b/.github/workflows/linux-build-scripts.yml
@@ -1,4 +1,6 @@
 name: linux build scripts
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/macos-build-scripts.yml
+++ b/.github/workflows/macos-build-scripts.yml
@@ -1,4 +1,6 @@
 name: macos build scripts
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/periodic-builds-android.yml
+++ b/.github/workflows/periodic-builds-android.yml
@@ -1,4 +1,6 @@
 name: android nightly builds
+permissions:
+  contents: read
 
 on:
   schedule:

--- a/.github/workflows/periodic-builds-apple.yml
+++ b/.github/workflows/periodic-builds-apple.yml
@@ -1,4 +1,6 @@
 name: apple nightly builds
+permissions:
+  contents: read
 
 on:
   schedule:

--- a/.github/workflows/tvos-build-scripts.yml
+++ b/.github/workflows/tvos-build-scripts.yml
@@ -1,4 +1,6 @@
 name: tvos build scripts
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/de-id/ffmpeg-kit/security/code-scanning/37](https://github.com/de-id/ffmpeg-kit/security/code-scanning/37)

To fix the problem, we should **explicitly declare the `permissions:` key** at the workflow root (so it applies to all jobs, unless overridden), specifying only the minimal access needed for this workflow. At a minimum, CodeQL suggests `contents: read`, but because the workflow creates releases (`softprops/action-gh-release`) and uploads artifacts, we likely need additional permissions:

- `contents: write` (for creating releases/assets)
- `actions: write` (for uploading artifacts, though `upload-artifact` does not require this)
- If we do not touch issues or PRs, avoid those permissions.

The best change is to add the following block just after the workflow `name` and before `on:` (so it covers all jobs in the workflow):

```yaml
permissions:
  contents: write
```

If you want to start with the most restrictive and only escalate if you discover errors, you can use `contents: read` initially. However, the `action-gh-release` will require `write` on contents to create releases. So `contents: write` is correct for this workflow.

Only the top region of `.github/workflows/android-build-scripts-did.yml` needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
